### PR TITLE
Add: basic asteroid collision object

### DIFF
--- a/scenes/Asteroid.tscn
+++ b/scenes/Asteroid.tscn
@@ -10,6 +10,9 @@ extents = Vector2( 15.049, 10.4424 )
 collision_layer = 4
 collision_mask = 3
 script = ExtResource( 1 )
+__meta__ = {
+"_edit_group_": true
+}
 
 [node name="Sprite" type="Sprite" parent="."]
 texture = ExtResource( 2 )

--- a/scenes/Asteroid.tscn
+++ b/scenes/Asteroid.tscn
@@ -6,10 +6,9 @@
 [sub_resource type="RectangleShape2D" id=1]
 extents = Vector2( 15.049, 10.4424 )
 
-[node name="Asteroid" type="RigidBody2D"]
+[node name="Asteroid" type="Area2D"]
 collision_layer = 4
 collision_mask = 3
-gravity_scale = 0.0
 script = ExtResource( 1 )
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/scenes/Player.tscn
+++ b/scenes/Player.tscn
@@ -25,4 +25,4 @@ shape = SubResource( 1 )
 one_shot = true
 autostart = true
 
-[connection signal="body_entered" from="." to="." method="_on_Player_body_entered"]
+[connection signal="area_entered" from="." to="." method="_on_Player_area_entered"]

--- a/scripts/Asteroid.gd
+++ b/scripts/Asteroid.gd
@@ -6,8 +6,8 @@ export (int) var min_rotation = 180
 export (int) var max_rotation = 200
 export (float) var rotation_speed = 1.0
 export (int) var speed = 100
+
 var screen_size
-var velocity = Vector2(100, 0)
 var screen_buffer = 8
 
 var motion = Vector2(1, 0)

--- a/scripts/Asteroid.gd
+++ b/scripts/Asteroid.gd
@@ -1,11 +1,16 @@
-extends RigidBody2D
+extends Area2D
+
+signal destroyed
 
 export (int) var min_rotation = 180
 export (int) var max_rotation = 200
-
+export (float) var rotation_speed = 1.0
+export (int) var speed = 100
 var screen_size
 var velocity = Vector2(100, 0)
 var screen_buffer = 8
+
+var motion = Vector2(1, 0)
 
 func _ready():
 	screen_size = get_viewport_rect().size
@@ -14,13 +19,19 @@ func _ready():
 func start(pos, dir):
 	position = pos
 	rotation = rand_range(min_rotation, max_rotation)
-	linear_velocity = Vector2(100, 0)
-	linear_velocity = linear_velocity.rotated(rotation)
+	motion = motion.rotated(dir)
 	show()
 	
-func _physics_process(delta):
+func _process(delta):
+	position += motion * speed * delta
+	
+	rotation_degrees += rotation_speed
+	
 	position.x = wrapf(position.x, -screen_buffer, screen_size.x + screen_buffer)
 	position.y = wrapf(position.y, -screen_buffer, screen_size.y + screen_buffer)
 
 func _on_Asteroid_body_entered(body):
-	print(body.get_name())
+	if body.get_name() == "Bullet":
+		body.queue_free()
+		queue_free()
+		emit_signal("destroyed")

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -30,5 +30,10 @@ func _on_SpawnTimer_timeout():
 	var asteroid = preload("res://scenes/Asteroid.tscn").instance()
 	add_child(asteroid)
 	asteroid.start(asteroid_position, direction)
+	asteroid.connect("destroyed", self, "_on_Asteroid_destroyed")
+	
+func _on_Asteroid_destroyed():
+	score += 1
+	$HUD.update_score(score)
 	
 

--- a/scripts/Player.gd
+++ b/scripts/Player.gd
@@ -50,7 +50,6 @@ func _process(delta):
 	position.y = wrapf(position.y, -screen_buffer, screen_size.y + screen_buffer)
 	
 
-func _on_Player_body_entered(body):
+func _on_Player_area_entered(area):
 	hide()
 	emit_signal("hit")
-	$CollisionShape2D.call_deferred("set_disabled", true)


### PR DESCRIPTION
Adds in the basic logic for asteroids to interact with bullets and the player.

Changed the asteroid root node type to Area2D and changed the physics logic accordingly. When a collision with a bullet is detected the asteroid and bullet despawn and the score is incremented.

Changed the collision detection on the Player from body_entered to area_entered to detect the new Asteroid type.